### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -193,7 +193,7 @@ def manual_check_urls():
         check_all_urls()
         return 'URL check completed', 200
     except Exception as e:
-        logging.exception("Error checking URLs")
+        logger.exception("Error checking URLs")
         return "An internal error occurred while checking URLs.", 500
 
 

--- a/app.py
+++ b/app.py
@@ -6,6 +6,10 @@ import requests
 from datetime import datetime, timedelta
 from flask import Flask, request, render_template, redirect, url_for, jsonify
 from flask_sqlalchemy import SQLAlchemy
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
 
 app = Flask(__name__)
 
@@ -189,7 +193,8 @@ def manual_check_urls():
         check_all_urls()
         return 'URL check completed', 200
     except Exception as e:
-        return f'Error checking URLs: {str(e)}', 500
+        logging.exception("Error checking URLs")
+        return "An internal error occurred while checking URLs.", 500
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Potential fix for [https://github.com/rottingresearch/qr-collector/security/code-scanning/4](https://github.com/rottingresearch/qr-collector/security/code-scanning/4)

To fix the problem, avoid returning internal exception messages to the user. Instead, log the exception (potentially including the stack trace) on the server, and return a generic error message to the user. 

Detailed steps:
- In the function `manual_check_urls()` (lines 186-193), replace the error response so that it does not include `str(e)`.
- Log the full exception details server-side using Python's `logging` module or similar. If the logging module is not already imported, add an import and configuration for logging at the top of the file.
- Return a generic error message such as `"An internal error occurred while checking URLs."` and status code 500 to the user.

Files/regions to change:
- In file `app.py`, modify the exception handler in `manual_check_urls()` to log the exception and return a generic message.
- Add an import for the `logging` module if it doesn't already exist and configure basic logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
